### PR TITLE
Flesh out some of the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,9 @@
 [![Documentation](https://docs.rs/asyncapiv3/badge.svg)](https://docs.rs/asyncapiv3)
 ![License](https://img.shields.io/crates/l/asyncapiv3.svg)
 
-Representation of the Asyncapi v3 spec
+Representation of the [AsyncAPI](https://www.asyncapi.com/) v3 specification.
+AsyncAPI is a standard inspired by OpenAPI/Swagger targetting asynchronous
+and event-driven APIs.
+
+This project aims to allow users to parse AsyncAPI specifications into Rust
+objects as well as creating and serializing AsyncAPI specifications.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "writer")]

--- a/src/spec/channel.rs
+++ b/src/spec/channel.rs
@@ -1,9 +1,12 @@
+//! Contains types related to the [channels field](https://www.asyncapi.com/docs/concepts/asyncapi-document/structure#channels-field).
 use crate::spec::common::{ExternalDocumentation, RefOr, ReferenceObject, Tag};
 use crate::spec::message::Messages;
 use std::collections::HashMap;
 
 pub type Channels = HashMap<String, RefOr<Channel>>;
 
+/// A channel represents the communication pathways through which messages are exchanged. You can
+/// specify their purpose, address, and the expected message formats for communication.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Channel {

--- a/src/spec/common.rs
+++ b/src/spec/common.rs
@@ -1,7 +1,12 @@
+//! Module for common types or utilities used throughout the specification.
+
+/// Either type used to store either one type or another.
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum Either<L, R> {
+    /// The first potentially stored type
     Left(L),
+    /// The second potentially stored type
     Right(R),
 }
 
@@ -18,25 +23,32 @@ where
     }
 }
 
+/// To prevent excessive repetitions of shared elements AsyncAPI allows you to refer to already
+/// defined objects via references. This type is used for serializing and deserializing said
+/// references.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ReferenceObject {
+    /// The reference for the referred to object
     #[serde(rename = "$ref")]
     pub reference: String,
 }
 
 impl ReferenceObject {
+    /// Creates a reference to a channel.
     pub fn new_channel(channel_name: &str) -> Self {
         Self {
             reference: format!("#/channels/{channel_name}"),
         }
     }
 
+    /// Creates a reference to a message.
     pub fn new_message(message_name: &str) -> Self {
         Self {
             reference: format!("#/components/messages/{message_name}"),
         }
     }
 
+    /// Creates a reference to a channel message.
     pub fn new_channel_message(channel_name: &str, message_name: &str) -> Self {
         Self {
             reference: format!("#/channels/{channel_name}/messages/{message_name}"),

--- a/src/spec/component.rs
+++ b/src/spec/component.rs
@@ -1,3 +1,5 @@
+//! Contains types related to the [components
+//! field](https://www.asyncapi.com/docs/concepts/asyncapi-document/structure#components-field).
 use crate::spec::channel::{Channel, ChannelBindings, Parameter};
 use crate::spec::common::{Either, ExternalDocumentation, RefOr, Tag};
 use crate::spec::message::{

--- a/src/spec/info.rs
+++ b/src/spec/info.rs
@@ -1,5 +1,13 @@
+//! Contains types related to the [info
+//! field](https://www.asyncapi.com/docs/concepts/asyncapi-document/structure#info-field)
 use crate::spec::common::{ExternalDocumentation, RefOr, Tag};
 
+/// The info field in an API document offers crucial metadata, including the API's title,
+/// version, description, contact details, and license. This field provides a
+/// comprehensive overview of the API, aiding developers, architects, and other
+/// stakeholders in quickly grasping its purpose and capabilities. As a mandatory element
+/// of the AsyncAPI specification, the info field often serves as the initial reference
+/// point for users navigating the API documentation.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Info {

--- a/src/spec/message.rs
+++ b/src/spec/message.rs
@@ -1,3 +1,6 @@
+//! Contains the [message
+//! object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#messageObject) and related
+//! types.
 use crate::spec::common::{Either, ExternalDocumentation, RefOr, Tag};
 use core::num::NonZeroU16;
 use std::collections::HashMap;

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -1,3 +1,4 @@
+//! Contains the types present in a specification.
 use crate::spec::channel::Channels;
 use crate::spec::component::Components;
 use crate::spec::info::Info;
@@ -13,13 +14,16 @@ pub mod operation;
 pub mod security;
 pub mod server;
 
+/// Enum to store a versioned instance of the specification.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "asyncapi")]
 pub enum AsyncApiSpec {
+    /// Version 3.0.0 of the specification
     #[serde(rename = "3.0.0")]
     V3_0_0(AsyncApiV3Spec),
 }
 
+/// Root type of an AsyncAPI 3 specification.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AsyncApiV3Spec {

--- a/src/spec/operation.rs
+++ b/src/spec/operation.rs
@@ -1,3 +1,5 @@
+//! Contains types related to the [operations
+//! field](https://www.asyncapi.com/docs/concepts/asyncapi-document/structure#operations-field)
 use crate::spec::common::{ExternalDocumentation, RefOr, ReferenceObject, Tag};
 use crate::spec::security::SecurityScheme;
 use std::collections::HashMap;

--- a/src/spec/security.rs
+++ b/src/spec/security.rs
@@ -1,5 +1,12 @@
+//! Represents the AsyncAPI security property as well as the various security schemes supported in
+//! the specification.
 use std::collections::HashMap;
 
+/// You can describe how your server is secured with the security property where you define
+/// which security schemes can be used with the server in context. Each server in the
+/// AsyncAPI document can have one or more security schemes declared. A security scheme
+/// defines a security requirement that must be satisfied to authorize an operation, such as an
+/// API key or a username and password.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SecurityScheme {
@@ -231,10 +238,14 @@ pub enum ApiKeyLocation {
     Password,
 }
 
+/// Represents where the users API key is located.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum HttpApiKeyLocation {
+    /// Located in the HTTP query string e.g. `?api_key=<KEY>`
     Query,
+    /// Located in a HTTP Header for example the `Authorization` header
     Header,
+    /// Located in a session cookie
     Cookie,
 }

--- a/src/spec/server.rs
+++ b/src/spec/server.rs
@@ -1,3 +1,5 @@
+//! Contains types related to the [servers
+//! field](https://www.asyncapi.com/docs/concepts/asyncapi-document/structure#servers-field)
 use crate::spec::common::{ExternalDocumentation, RefOr, Tag};
 use crate::spec::security::SecurityScheme;
 use std::collections::HashMap;


### PR DESCRIPTION
I didn't touch the builder as I saw an issue for it and wasn't sure if it was going to change substantially. Just filling in a bit of basic docs stuff. A bunch of links to asyncapi docs for reference to make it easier to cross reference things.

Before:

| File                                | Documented | Percentage | Examples | Percentage |
|-------------------------------------|------------|------------|----------|------------|
| src/builder/mod.rs                  | 0          | 0.0%       | 0        | 0.0%       |
| src/builder/operation.rs            | 0          | 0.0%       | 0        | 0.0%       |
| src/error.rs                        | 0          | 0.0%       | 0        | 0.0%       |
| src/lib.rs                          | 0          | 0.0%       | 0        | 0.0%       |
| src/spec/channel.rs                 | 23         | 65.7%      | 0        | 0.0%       |
| src/spec/common.rs                  | 5          | 29.4%      | 0        | 0.0%       |
| src/spec/component.rs               | 20         | 95.2%      | 0        | 0.0%       |
| src/spec/info.rs                    | 13         | 76.5%      | 0        | 0.0%       |
| src/spec/message.rs                 | 39         | 78.0%      | 0        | 0.0%       |
| src/spec/mod.rs                     | 7          | 63.6%      | 0        | 0.0%       |
| src/spec/operation.rs               | 33         | 58.9%      | 0        | 0.0%       |
| src/spec/security.rs                | 26         | 39.4%      | 0        | 0.0%       |
| src/spec/server.rs                  | 16         | 59.3%      | 0        | 0.0%       |
| **Total**                           | **182**    | **54.2%**  | **0**    | **0.0%**   |


After: 

| File                                | Documented | Percentage | Examples | Percentage |
|-------------------------------------|------------|------------|----------|------------|
| src/builder/mod.rs                  | 0          | 0.0%       | 0        | 0.0%       |
| src/builder/operation.rs            | 0          | 0.0%       | 0        | 0.0%       |
| src/error.rs                        | 0          | 0.0%       | 0        | 0.0%       |
| src/lib.rs                          | 1          | 100.0%     | 0        | 0.0%       |
| src/spec/channel.rs                 | 25         | 71.4%      | 0        | 0.0%       |
| src/spec/common.rs                  | 14         | 82.4%      | 0        | 0.0%       |
| src/spec/component.rs               | 21         | 100.0%     | 0        | 0.0%       |
| src/spec/info.rs                    | 15         | 88.2%      | 0        | 0.0%       |
| src/spec/message.rs                 | 40         | 80.0%      | 0        | 0.0%       |
| src/spec/mod.rs                     | 11         | 100.0%     | 0        | 0.0%       |
| src/spec/operation.rs               | 34         | 60.7%      | 0        | 0.0%       |
| src/spec/security.rs                | 32         | 48.5%      | 0        | 0.0%       |
| src/spec/server.rs                  | 17         | 63.0%      | 0        | 0.0%       |
| **Total**                           | **210**    | **62.5%**  | **0**    | **0.0%**   |
